### PR TITLE
added remote queries with a fallback for older plugin hosts

### DIFF
--- a/nextprevlinks.js
+++ b/nextprevlinks.js
@@ -3,9 +3,10 @@ const View = require("@saltcorn/data/models/view");
 const Workflow = require("@saltcorn/data/models/workflow");
 const Table = require("@saltcorn/data/models/table");
 const Form = require("@saltcorn/data/models/form");
-const Field = require("@saltcorn/data/models/field");
 const db = require("@saltcorn/data/db");
 const { stateFieldsToWhere } = require("@saltcorn/data/plugin-helper");
+
+const isNode = typeof window === "undefined";
 
 const configuration_workflow = () =>
   new Workflow({
@@ -78,13 +79,7 @@ const get_state_fields = () => [
   },
 ];
 
-const run = async (
-  table_id,
-  viewname,
-  { link_view, label_field, fixed_label, order_field, descending },
-  state,
-  extraArgs
-) => {
+const queryImpl = async (table_id, state, descending, order_field) => {
   const table = await Table.findOne({ id: table_id });
   const fields = await table.getFields();
   const qstate = await stateFieldsToWhere({ fields, state });
@@ -94,20 +89,35 @@ const run = async (
   if (!current_row) return "";
   const dir = descending ? "desc" : "asc";
   const cmp = descending ? "<" : ">";
-  const {
-    rows,
-  } = await db.query(
+  return await db.query(
     `select * from ${schema}"${table.name}" where ${order_field} ${cmp} $1 OR (${order_field}=$2 AND ${pk.name}${cmp} $3) order by ${order_field} ${dir}, ${pk.name} ${dir} limit 1`,
     [current_row[order_field], current_row[order_field], current_row[pk.name]]
   );
+};
+
+const run = async (
+  table_id,
+  viewname,
+  { link_view, label_field, fixed_label, order_field, descending },
+  state,
+  extraArgs,
+  queriesObj
+) => {
+  const { rows } = queriesObj?.rowsQuery
+    ? await queriesObj.rowsQuery(state)
+    : await queryImpl(table_id, state, descending, order_field);
+  const table = await Table.findOne({ id: table_id });
+  const fields = await table.getFields();
+  const pk = fields.find((f) => f.primary_key);
   if (rows && rows.length > 0) {
+    const target = `/view/${encodeURIComponent(link_view)}?${encodeURIComponent(
+      pk.name
+    )}=${encodeURIComponent(rows[0][pk.name])}`;
     return (
       (label_field ? fixed_label || "" : "") +
       a(
         {
-          href: `/view/${encodeURIComponent(link_view)}?${encodeURIComponent(
-            pk.name
-          )}=${encodeURIComponent(rows[0][pk.name])}`,
+          href: isNode ? target : `javascript:parent.execLink('${target}')`,
         },
         `${label_field ? text(rows[0][label_field]) : fixed_label || ""}`
       )
@@ -120,4 +130,15 @@ module.exports = {
   get_state_fields,
   configuration_workflow,
   run,
+  queries: ({
+    table_id,
+    name,
+    configuration: { order_field, descending },
+    req,
+    res,
+  }) => ({
+    async rowsQuery(state) {
+      return await queryImpl(table_id, state, descending, order_field);
+    },
+  }),
 };


### PR DESCRIPTION
- added 'count_rows_query()' to Stepper and 'rowsQuery()' to PreviousOrNextLink
- if the plugin host sends no queries, the query impl will be called directly